### PR TITLE
fix: treat `version` as `str` and not `float`

### DIFF
--- a/moderne_visualizations_misc/gradle_wrappers.ipynb
+++ b/moderne_visualizations_misc/gradle_wrappers.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "from code_data_science import data_table as dt\n",
     "\n",
-    "df = dt.read_csv(\"../samples/gradle_wrappers.csv\")\n",
+    "df = dt.read_csv(\"../samples/gradle_wrappers.csv\", dtype={\"version\": str})\n",
     "df.head()"
    ]
   },
@@ -73,7 +73,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Avoid truncation of `8.10` to `8.10` when rendering plot

fix https://github.com/moderneinc/moderne-visualizations-misc/issues/54
