### PR TITLE
No longer map plain text `.py` to Python

### DIFF
--- a/moderne_visualizations_misc/language_composition.ipynb
+++ b/moderne_visualizations_misc/language_composition.ipynb
@@ -47,7 +47,6 @@
     "    mappings = {\n",
     "        \"Typescript\": [\"ts\", \"tsx\"],\n",
     "        \"Javascript\": [\"js\", \"jsx\"],\n",
-    "        \"Python\": [\"py\"],\n",
     "        \"Kotlin\": [\"kts\"],\n",
     "    }\n",
     "\n",

--- a/moderne_visualizations_misc/language_composition_by_repo.ipynb
+++ b/moderne_visualizations_misc/language_composition_by_repo.ipynb
@@ -47,7 +47,6 @@
     "    mappings = {\n",
     "        \"Typescript\": [\"ts\", \"tsx\"],\n",
     "        \"Javascript\": [\"js\", \"jsx\"],\n",
-    "        \"Python\": [\"py\"],\n",
     "        \"Kotlin\": [\"kts\"],\n",
     "    }\n",
     "\n",


### PR DESCRIPTION
We now use the Python parser for `.py` sources and no longer want to map the plain text `.py` files (of projects which haven't been ingested recently) to the Python group.
