### PR TITLE
fix: add missing .table. package in dataTable references

### DIFF
--- a/moderne_visualizations_misc/specs/release_metro_map.yml
+++ b/moderne_visualizations_misc/specs/release_metro_map.yml
@@ -7,10 +7,10 @@ description: >
   Nodes represent repositories and edges show dependency and parent relationships.
   Helps visualize the dependency structure to plan coordinated multi-repository releases.
 recipe: io.moderne.recipe.releasemetro.ReleaseMetroPlan
-dataTable: io.moderne.recipe.releasemetro.ProjectCoordinates
+dataTable: io.moderne.recipe.releasemetro.table.ProjectCoordinates
 additionalDataTables:
   data_file_dependencies: org.openrewrite.maven.table.DependenciesInUse
-  data_file_parents: io.moderne.recipe.releasemetro.ParentRelationships
+  data_file_parents: io.moderne.recipe.releasemetro.table.ParentRelationships
 options:
   - repository_filter:
       displayName: Repository filter

--- a/moderne_visualizations_misc/specs/release_metro_plan.yml
+++ b/moderne_visualizations_misc/specs/release_metro_plan.yml
@@ -7,10 +7,10 @@ description: >
   from left to right, with directed edges showing dependency flow. Visualizes both the
   dependency complexity and the sequential release order in a single view.
 recipe: io.moderne.recipe.releasemetro.ReleaseMetroPlan
-dataTable: io.moderne.recipe.releasemetro.ProjectCoordinates
+dataTable: io.moderne.recipe.releasemetro.table.ProjectCoordinates
 additionalDataTables:
   data_file_dependencies: org.openrewrite.maven.table.DependenciesInUse
-  data_file_parents: io.moderne.recipe.releasemetro.ParentRelationships
+  data_file_parents: io.moderne.recipe.releasemetro.table.ParentRelationships
 options:
   - repository_filter:
       displayName: Repository filter

--- a/moderne_visualizations_misc/specs/release_metro_waves.yml
+++ b/moderne_visualizations_misc/specs/release_metro_waves.yml
@@ -7,10 +7,10 @@ description: >
   Wave 0 contains repositories with no internal dependencies that can release first.
   Each subsequent wave depends only on earlier waves, enabling parallel releases within a wave.
 recipe: io.moderne.recipe.releasemetro.ReleaseMetroPlan
-dataTable: io.moderne.recipe.releasemetro.ProjectCoordinates
+dataTable: io.moderne.recipe.releasemetro.table.ProjectCoordinates
 additionalDataTables:
   data_file_dependencies: org.openrewrite.maven.table.DependenciesInUse
-  data_file_parents: io.moderne.recipe.releasemetro.ParentRelationships
+  data_file_parents: io.moderne.recipe.releasemetro.table.ParentRelationships
 options:
   - repository_filter:
       displayName: Repository filter


### PR DESCRIPTION
## Summary
- All three release metro visualization specs (`release_metro_map`, `release_metro_plan`, `release_metro_waves`) referenced `io.moderne.recipe.releasemetro.ProjectCoordinates` and `io.moderne.recipe.releasemetro.ParentRelationships`
- The actual Java classes live at `io.moderne.recipe.releasemetro.table.ProjectCoordinates` and `io.moderne.recipe.releasemetro.table.ParentRelationships` (note the `.table.` sub-package)
- This mismatch caused the UI to show "You cannot run this visualization at the moment because the required data is currently unavailable" for all three visualizations

## Test plan
- [ ] Deploy updated specs and verify visualizations are runnable against a `ReleaseMetroPlan` recipe run